### PR TITLE
Add macOS support

### DIFF
--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -104,7 +104,7 @@
                                     <include>me.hugmanrique:slime-core</include>
                                     <include>net.bytebuddy:byte-buddy</include>
                                     <include>net.bytebuddy:byte-buddy-agent</include>
-                                    <include>com.github.luben:zstd-jni:*:darwin-x86_64</include>
+                                    <include>com.github.luben:zstd-jni:*:darwin_x86_64</include>
                                 </includes>
                             </artifactSet>
                         </configuration>

--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -91,6 +91,24 @@
                             </artifactSet>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>shade-darwin</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <outputFile>target/${artifact.name}-darwin-x86_64.jar</outputFile>
+                            <artifactSet>
+                                <includes>
+                                    <include>me.hugmanrique:slime-core</include>
+                                    <include>net.bytebuddy:byte-buddy</include>
+                                    <include>net.bytebuddy:byte-buddy-agent</include>
+                                    <include>com.github.luben:zstd-jni:*:darwin-x86_64</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
                 </executions>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -30,6 +30,11 @@
             <classifier>win_amd64</classifier>
         </dependency>
         <dependency>
+            <groupId>com.github.luben</groupId>
+            <artifactId>zstd-jni</artifactId>
+            <classifier>darwin_x86_64</classifier>
+        </dependency>
+        <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <javac.target>1.8</javac.target>
         <minecraft.version>1.8.8-R0.1-SNAPSHOT</minecraft.version>
-        <zstd.version>1.4.1-1</zstd.version>
+        <zstd.version>1.4.4-7</zstd.version>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
                 <groupId>com.github.luben</groupId>
                 <artifactId>zstd-jni</artifactId>
                 <version>${zstd.version}</version>
-                <classifier>darwin-x86_64</classifier>
+                <classifier>darwin_x86_64</classifier>
             </dependency>
             <dependency>
                 <groupId>net.bytebuddy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,12 @@
                 <classifier>win_amd64</classifier>
             </dependency>
             <dependency>
+                <groupId>com.github.luben</groupId>
+                <artifactId>zstd-jni</artifactId>
+                <version>${zstd.version}</version>
+                <classifier>darwin-x86_64</classifier>
+            </dependency>
+            <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
                 <version>1.9.15</version>


### PR DESCRIPTION
Provides support for the darwin-x86_64 architecture.
Also updates zstd-jni to 1.4.4-7